### PR TITLE
feat: add CLI script for end-to-end modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ pnpm i #确保电脑安装了 pnpm
 pnpm run dev
 ```
 
+### ⚡ 一键生成建模论文
+
+完成上述依赖配置后，在 `backend` 目录下准备 `.env.dev`（或设置相应环境变量），脚本会自动加载这些配置。然后即可使用脚本快速运行完整流程：
+
+```bash
+cd backend
+uv run python run_pipeline.py --file path/to/questions.txt
+```
+
+生成的结果将保存在 `backend/project/work_dir/<task_id>/` 目录下。
+
 
 ### 🚀 方案三：自动脚本部署（来自社区）
 有没有自动部署的脚本 ？

--- a/README_EN.md
+++ b/README_EN.md
@@ -155,6 +155,17 @@ Results and outputs are generated in the `backend/project/work_dir/xxx/*` direct
 - notebook.ipynb: code generated during execution
 - res.md: final results in markdown format
 
+### ⚡ One-Click Paper Generation
+
+After installing the dependencies, create an `.env.dev` file under `backend` (or set the needed environment variables). The script will load these automatically. Then you can run the entire workflow via CLI:
+
+```bash
+cd backend
+uv run python run_pipeline.py --file path/to/questions.txt
+```
+
+The results will be stored in `backend/project/work_dir/<task_id>/`.
+
 ### 🚀 Option 3: Automated Script Deployment (Community Contribution)
 Need an automatic deployment script?
 [mmaAutoSetupRun](https://github.com/Fitia-UCAS/mmaAutoSetupRun)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pydantic>=2.10.6",
     "pydantic-settings>=2.8.0",
     "pypandoc-binary>=1.15",
+    "python-dotenv>=1.0.1",
     "redis>=5.2.1",
     "scikit-learn>=1.6.1",
     "scipy>=1.15.2",

--- a/backend/run_pipeline.py
+++ b/backend/run_pipeline.py
@@ -1,0 +1,50 @@
+import argparse
+import asyncio
+from dotenv import load_dotenv
+from app.core.workflow import MathModelWorkFlow
+from app.schemas.request import Problem
+from app.schemas.enums import CompTemplate, FormatOutPut
+from app.utils.common_utils import create_task_id, create_work_dir
+
+
+async def main(args: argparse.Namespace) -> None:
+    """Run the modeling workflow with CLI arguments."""
+
+    # Load environment variables from .env files for API keys, etc.
+    load_dotenv()
+
+    if args.question:
+        ques_all = args.question
+    elif args.file:
+        with open(args.file, "r", encoding="utf-8") as f:
+            ques_all = f.read()
+    else:
+        raise ValueError("please provide --question or --file")
+
+    task_id = create_task_id()
+    create_work_dir(task_id)
+    problem = Problem(
+        task_id=task_id,
+        ques_all=ques_all,
+        comp_template=CompTemplate[args.template],
+        format_output=FormatOutPut[args.format],
+    )
+    await MathModelWorkFlow().execute(problem)
+    print(f"Task {task_id} finished. Results saved to project/work_dir/{task_id}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run full math modeling pipeline")
+    parser.add_argument("--question", type=str, help="Problem statement text")
+    parser.add_argument("--file", type=str, help="Path to text file containing problem statement")
+    parser.add_argument(
+        "--template", type=str, default="CHINA", choices=[e.name for e in CompTemplate]
+    )
+    parser.add_argument(
+        "--format", type=str, default="Markdown", choices=[e.name for e in FormatOutPut]
+    )
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    asyncio.run(main(parse_args()))


### PR DESCRIPTION
## Summary
- load `.env` automatically in `run_pipeline.py` for smoother CLI usage
- document `.env.dev` requirement for one-click workflow in both READMEs
- add `python-dotenv` dependency to backend

## Testing
- `uv run ruff check backend/run_pipeline.py backend/pyproject.toml`
- `uv run pytest` *(fails: Failed to fetch: `https://pypi.org/simple/pydantic-settings/`)*

------
https://chatgpt.com/codex/tasks/task_b_68aef75d0e54832c849befc8d47a4b71